### PR TITLE
Fix bug:clean first when previous commit of 'compatible with Gradle version from 8.2.1 to current latest 8.14.2'

### DIFF
--- a/source/gradle.properties
+++ b/source/gradle.properties
@@ -1,3 +1,3 @@
 PUBLISH_GROUP_ID=com.github.shenghua-ok
 PUBLISH_ARTIFACT_ID=fat-aar-android
-PUBLISH_VERSION=1.4.3
+PUBLISH_VERSION=1.4.4

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -14,6 +14,7 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
+import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -289,6 +290,12 @@ class VariantProcessor {
                 taskDep = artifact.buildDependencies
             } else if (artifact.metaClass.hasProperty(artifact, 'builtBy')) {
                 taskDep = artifact.builtBy
+            } else if (artifact.metaClass.hasProperty(artifact, 'id')) {
+                def artiId = artifact.getId()
+                if (artiId instanceof PublishArtifactLocalArtifactMetadata) {
+                    def metadata = (PublishArtifactLocalArtifactMetadata) artiId
+                    taskDep = metadata.buildDependencies
+                }
             }
         } catch (Exception ignore) {
             ignore.printStackTrace()


### PR DESCRIPTION
fix task 'explodexxxxFlavor2Debug' failure: can not found :libaar:xxxxDebug.aar when Gradle version >= 8.6